### PR TITLE
Translated the 'z' cone constraint to 'f' in format_and_copy_cone(con…

### DIFF
--- a/cyscs/_util.py
+++ b/cyscs/_util.py
@@ -85,6 +85,9 @@ def format_and_copy_cone(cone_in):
     for key in 'f', 'l', 'ep', 'ed':
         if key in cone_in:
             cone_out[key] = cone_in[key]
+            
+    if 'z' in cone_in:
+            cone_out['f'] = cone_in['z']
 
     for key in 'q', 's':
         if key in cone_in and len(cone_in[key]) > 0:


### PR DESCRIPTION
…e) function in [cyscs/_util.py](https://github.com/ajfriend/cyscs/blob/master/cyscs/_util.py). 

SCS's core programs in C consider 'f' as the number of linear equality constraints (primal zero, dual free) even though the new version on the website reflects this as 'z'. Turns out they both are the same cone constraints. So, I made this modification so that if we get 'z' it is still processed as 'f'.